### PR TITLE
Add domain event support to Entity base class

### DIFF
--- a/BookLibrary/src/BookLibrary.Domain/Abstractions/Entity.cs
+++ b/BookLibrary/src/BookLibrary.Domain/Abstractions/Entity.cs
@@ -2,10 +2,17 @@ namespace Hostly.Domain.Abstractions;
 
 public abstract class Entity
 {
+    private readonly List<IDomainEvent> _domainEvents = new();
     protected Entity(Guid id)
     {
         Id = id;
     }
 
     public Guid Id { get; init; }
+
+    public IReadOnlyCollection<IDomainEvent> GetDomainEvents() => _domainEvents.AsReadOnly();
+
+    public void ClearDomainEvents() => _domainEvents.Clear();
+    
+    protected void RaiseDomainEvent(IDomainEvent domainEvent) => _domainEvents.Add(domainEvent);
 }

--- a/BookLibrary/src/BookLibrary.Domain/Abstractions/IDomainEvent.cs
+++ b/BookLibrary/src/BookLibrary.Domain/Abstractions/IDomainEvent.cs
@@ -1,0 +1,7 @@
+﻿using MediatR;
+
+namespace Hostly.Domain;
+
+public interface IDomainEvent : INotification
+{
+}

--- a/BookLibrary/src/BookLibrary.Domain/Hostly.Domain.csproj
+++ b/BookLibrary/src/BookLibrary.Domain/Hostly.Domain.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="MediatR.Contracts" Version="2.0.1" />
+  </ItemGroup>
+  
 </Project>

--- a/BookLibrary/src/BookLibrary.Domain/Users/Events/UserCreatedDomainEvent.cs
+++ b/BookLibrary/src/BookLibrary.Domain/Users/Events/UserCreatedDomainEvent.cs
@@ -1,0 +1,6 @@
+﻿namespace Hostly.Domain;
+
+public record class UserCreatedDomainEvent(Guid UserId) : IDomainEvent
+{
+
+}

--- a/BookLibrary/src/BookLibrary.Domain/Users/User.cs
+++ b/BookLibrary/src/BookLibrary.Domain/Users/User.cs
@@ -4,7 +4,7 @@ namespace Hostly.Domain;
 
 public sealed class User : Entity  
 {
-    public User(Guid id, FirstName firstName, LastName lastName, Email email) : base(id)
+    private User(Guid id, FirstName firstName, LastName lastName, Email email) : base(id)
     {
         FirstName = firstName;
         LastName = lastName;
@@ -12,14 +12,13 @@ public sealed class User : Entity
     }
 
     public FirstName FirstName { get; private set; }
-
     public LastName LastName { get; private set; }
-
     public Email Email { get; private set; }
 
     public static User Create(FirstName firstName, LastName lastName, Email email)
     {
         var user = new User(Guid.NewGuid(), firstName, lastName, email);
+        user.RaiseDomainEvent(new UserCreatedDomainEvent(user.Id));
         return user;
     }
 }


### PR DESCRIPTION
# Add domain event support to Entity base class

## Summary
- Extended the **Entity** base class to include domain event handling.  
- Provides mechanisms for raising, accessing, and clearing domain events within entities.  

## Details
- Introduced a private list `_domainEvents` to track events raised by the entity.  
- Added methods:
  - `GetDomainEvents()` → returns an immutable collection of raised events.  
  - `ClearDomainEvents()` → clears all tracked events.  
  - `RaiseDomainEvent(IDomainEvent domainEvent)` → protected method for entities to raise events.  
- Ensures that events are encapsulated within the entity and exposed in a controlled manner.  

## Why
- Implements the **Domain Events pattern** to improve decoupling between entities and side effects.  
- Provides a consistent way for entities to raise events that can be published later (via MediatR).  
- Aligns with **DDD best practices** and lays the groundwork for an event-driven architecture.  
