### PR TITLE
Add domain interfaces for UnitOfWork, IApartmentRepository, and IUserRepository

### DIFF
--- a/BookLibrary/src/BookLibrary.Domain/Abstractions/IUnitOfWork.cs
+++ b/BookLibrary/src/BookLibrary.Domain/Abstractions/IUnitOfWork.cs
@@ -1,0 +1,6 @@
+﻿namespace Hostly.Domain;
+
+public interface IUnitOfWork
+{
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/BookLibrary/src/BookLibrary.Domain/Apartments/IApartamentRepository.cs
+++ b/BookLibrary/src/BookLibrary.Domain/Apartments/IApartamentRepository.cs
@@ -1,0 +1,6 @@
+﻿namespace Hostly.Domain;
+
+public interface IApartamentRepository
+{
+    Task<Apartment> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+}

--- a/BookLibrary/src/BookLibrary.Domain/Users/IUserRepository.cs
+++ b/BookLibrary/src/BookLibrary.Domain/Users/IUserRepository.cs
@@ -1,0 +1,7 @@
+﻿namespace Hostly.Domain;
+
+public interface IUserRepository
+{
+    Task<User> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    void Add(User user);
+}


### PR DESCRIPTION
#Add domain interfaces for UnitOfWork, IApartmentRepository, and IUserRepository

## Summary
- Introduced `IUnitOfWork`, `IApartmentRepository`, and `IUserRepository` interfaces in the domain layer.  
- These define contracts for persistence operations and transactions.  

## Details
- Added **IUnitOfWork** to coordinate transactional consistency across repositories.  
- Added **IApartmentRepository** to handle persistence for `Apartment` entities.  
- Added **IUserRepository** to handle persistence for `User` entities.  

## Why
- Establishes a clear separation between domain and infrastructure concerns.  
- Provides contracts that will guide repository implementations.  
- Aligns with DDD practices by encapsulating persistence logic behind interfaces.  
